### PR TITLE
Introduce worker pool for backend API

### DIFF
--- a/Gomfile
+++ b/Gomfile
@@ -4,6 +4,7 @@ gom 'github.com/alext/tablecloth'
 gom 'github.com/cenkalti/backoff'
 gom 'github.com/codegangsta/inject'
 gom 'github.com/go-martini/martini'
+gom 'github.com/golang/groupcache'
 gom 'github.com/google/go-querystring/query'
 gom 'gopkg.in/unrolled/render.v1'
 

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ test:
 	find . -name '*.coverprofile' -type f -exec sed -i '' 's|_'$(CURDIR)'|\.|' {} \;
 
 build:
-	GO_ENABLED=0 GOOS=$(GOOS) gom build -a -tags netgo -ldflags '-w' -o $(BINARY) .
+	GO_ENABLED=0 GOOS=$(GOOS) gom build -race -a -tags netgo -ldflags '-w' -o $(BINARY) .
 
 clean:
 	rm -rf $(BINARY)


### PR DESCRIPTION
I don’t think this is thread-safe, but it’s a start towards deduplicating
backing service requests.
Approach inspired by
http://blog.gitorious.org/2014/08/11/golang-patterns-for-serving-on-demand-generated-content/
