### PR TITLE
Use SPDY to talk to backing services

### DIFF
--- a/Gomfile
+++ b/Gomfile
@@ -1,11 +1,12 @@
 gom 'github.com/Sirupsen/logrus'
-gom 'github.com/alphagov/performanceplatform-client.go', :commit => 'e89f8757f3f0fab0e2f5fdb7efbcc6f8f2ddfb9e'
+gom 'github.com/alphagov/performanceplatform-client.go', :commit => 'cf5645ec19680fed098ce5c304ac238e52eb75e8'
 gom 'github.com/alext/tablecloth'
 gom 'github.com/cenkalti/backoff'
 gom 'github.com/codegangsta/inject'
 gom 'github.com/go-martini/martini'
 gom 'github.com/golang/groupcache'
 gom 'github.com/google/go-querystring/query'
+gom 'github.com/SlyMarbo/spdy'
 gom 'gopkg.in/unrolled/render.v1'
 
 group :test do

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/Sirupsen/logrus"
+	_ "github.com/SlyMarbo/spdy" // This adds SPDY client support to net/http
 	"github.com/alext/tablecloth"
 	"github.com/alphagov/performanceplatform-client.go"
 	"net/http"


### PR DESCRIPTION
This should give a performance boost by requiring fewer network
connections (and thus less overhead in setting up TLS TCP connections).

I’ve had a couple of issues fixed in the underlying library, so this
works now.

```
> echo 'GET http://localhost:8080/performance/carers-allowance' | vegeta attack -rate=30 | vegeta report
2015/03/02 20:59:42 Vegeta is attacking 1 targets in random order for 10s...
2015/03/02 20:59:52 Done! Writing results to 'stdout'...
Requests    [total]             300
Duration    [total]             9.966348272s
Latencies   [mean, 50, 95, 99, max]     213.692567ms, 212.855412ms, 278.522824ms, 354.843793ms, 420.539751ms
Bytes In    [total, mean]           152100, 507.00
Bytes Out   [total, mean]           0, 0.00
Success     [ratio]             100.00%
Status Codes    [code:count]            200:300  
Error Set:
```
